### PR TITLE
Add execute plan for other DBMS

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,6 +1,7 @@
 [
     { "keys": ["ctrl+alt+e"], "command": "st_select_connection" },
     { "keys": ["ctrl+e", "ctrl+e"], "command": "st_execute" },
+    { "keys": ["ctrl+e", "ctrl+x"], "command": "st_explain_plan" },
     { "keys": ["ctrl+e", "ctrl+h"], "command": "st_history" },
     { "keys": ["ctrl+e", "ctrl+s"], "command": "st_show_records" },
     { "keys": ["ctrl+e", "ctrl+d"], "command": "st_desc_table" },

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,6 +1,7 @@
 [
     { "keys": ["ctrl+alt+e"], "command": "st_select_connection" },
     { "keys": ["ctrl+e", "ctrl+e"], "command": "st_execute" },
+    { "keys": ["ctrl+e", "ctrl+x"], "command": "st_explain_plan" },
     { "keys": ["ctrl+e", "ctrl+h"], "command": "st_history" },
     { "keys": ["ctrl+e", "ctrl+s"], "command": "st_show_records" },
     { "keys": ["ctrl+e", "ctrl+d"], "command": "st_desc_table" },

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,6 +1,7 @@
 [
     { "keys": ["ctrl+alt+e"], "command": "st_select_connection" },
     { "keys": ["ctrl+e", "ctrl+e"], "command": "st_execute" },
+    { "keys": ["ctrl+e", "ctrl+x"], "command": "st_explain_plan" },
     { "keys": ["ctrl+e", "ctrl+h"], "command": "st_history" },
     { "keys": ["ctrl+e", "ctrl+s"], "command": "st_show_records" },
     { "keys": ["ctrl+e", "ctrl+d"], "command": "st_desc_table" },

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -77,6 +77,11 @@
                     "query": "\\sf %s",
                     "options": [],
                     "format" : "|%s|"
+                },
+                "explain plan": {
+                    "query": "explain {0}",
+                    "options": [],
+                    "format" : "|%s|"
                 }
             }
         },
@@ -151,6 +156,11 @@
                     "query": "SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = DATABASE();",
                     "options": ["-f", "--table"],
                     "format" : "|%s|"
+                },
+                "explain plan": {
+                    "query": "explain {0}",
+                    "options": ["-f", "--table"],
+                    "format" : "|%s|"
                 }
             }
         },
@@ -171,6 +181,11 @@
                 },
                 "show records": {
                     "query": "select * from {0} limit {1}",
+                    "options": [],
+                    "format" : "|%s|"
+                },
+                "explain plan": {
+                    "query": "explain {0}",
                     "options": [],
                     "format" : "|%s|"
                 }
@@ -218,6 +233,11 @@
                 },
                 "show records": {
                     "query": "select * from \"{0}\" limit {1};",
+                    "options": ["-column"],
+                    "format" : "|%s|"
+                },
+                "explain plan": {
+                    "query": "EXPLAIN QUERY PLAN {0}",
                     "options": ["-column"],
                     "format" : "|%s|"
                 }

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -79,7 +79,7 @@
                     "format" : "|%s|"
                 },
                 "explain plan": {
-                    "query": "explain {0}",
+                    "query": "explain {0};",
                     "options": [],
                     "format" : "|%s|"
                 }
@@ -158,7 +158,7 @@
                     "format" : "|%s|"
                 },
                 "explain plan": {
-                    "query": "explain {0}",
+                    "query": "explain {0};",
                     "options": ["-f", "--table"],
                     "format" : "|%s|"
                 }
@@ -185,7 +185,7 @@
                     "format" : "|%s|"
                 },
                 "explain plan": {
-                    "query": "explain {0}",
+                    "query": "explain {0};",
                     "options": [],
                     "format" : "|%s|"
                 }
@@ -237,7 +237,7 @@
                     "format" : "|%s|"
                 },
                 "explain plan": {
-                    "query": "EXPLAIN QUERY PLAN {0}",
+                    "query": "EXPLAIN QUERY PLAN {0};",
                     "options": ["-column"],
                     "format" : "|%s|"
                 }

--- a/SQLToolsAPI/Connection.py
+++ b/SQLToolsAPI/Connection.py
@@ -107,7 +107,11 @@ class Connection:
         self.Command.createAndRun(self.builArgs('desc function'), queryToRun, callback)
 
     def explainPlan(self, queries, callback):
-        queryFormat = self.getOptionsForSgdbCli()['queries']['explain plan']['query']
+        try:
+            queryFormat = self.getOptionsForSgdbCli()['queries']['explain plan']['query']
+        except KeyError:
+            return # do nothing, if DBMS has no support for explain plan
+
         stripped_queries = [
             queryFormat.format(query.strip().strip(";"))
             for rawQuery in queries

--- a/SQLToolsAPI/Connection.py
+++ b/SQLToolsAPI/Connection.py
@@ -111,7 +111,7 @@ class Connection:
         stripped_queries = [
             queryFormat.format(query.strip().strip(";"))
             for rawQuery in queries
-            for query in sqlparse.split(rawQuery)
+            for query in filter(None, sqlparse.split(rawQuery))
         ]
         queryToRun = '\n'.join(self.getOptionsForSgdbCli()['before'] + stripped_queries)
         self.Command.createAndRun(self.builArgs('explain plan'), queryToRun, callback)


### PR DESCRIPTION
Added explain query for:

  * PostgreSQL
  * MySQL
  * Vertica
  * SQLite

As well as added default keyboard shortcut [ctrl+e, ctrl+x] for explain plan command.